### PR TITLE
Update dependency for clap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,5 @@ edition = "2018"
 num-traits = "0.2"
 num-derive = "0.3"
 itertools = "0.10.0"
-clap = "3.0.0-beta.2"
+clap = { git = "https://github.com/clap-rs/clap", rev = "08b2f4d4289eca8a9225bbc56d5a5ad1e99e38e1" }
 


### PR DESCRIPTION
Looks like Cargo doesn't like the betas and it will instead fetch the latest version of the major (which is now 3.2.22). I don't know why but this fixes it.